### PR TITLE
Add support for single page checkout (SH-290)

### DIFF
--- a/shuup_stripe/templates/shuup/stripe/checkout_phase.jinja
+++ b/shuup_stripe/templates/shuup/stripe/checkout_phase.jinja
@@ -1,7 +1,7 @@
 {% extends "shuup/front/checkout/_base.jinja" %}
 
-{% block content %}
-<form role="form" method="post" action="">
+{% block checkout_phase_content %}
+<form role="form" method="post" action="{{ url('shuup:checkout', phase="payment") }}">
     {% csrf_token %}
     <div class="row">
         <div class="col-md-12 text-center">


### PR DESCRIPTION
Add support for `shuup.front.checkout.SiglePageCheckoutView`.

https://github.com/shuup/shuup/pull/854 should be merged first
