### PR TITLE
Move `StripeTokenForm` to separate file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,27 @@
 [bdist_wheel]
 universal = 1
 
+[flake8]
+exclude = .tox,migrations,doc/*
+max-line-length = 120
+max-complexity = 10
+
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = test_settings
 django_find_project = false
 norecursedirs = bower_components node_modules .git venv
+
+[isort]
+atomic=true
+combine_as_imports=false
+indent=4
+known_first_party=shuup_stripe
+known_standard_library=token,tokenize,enum,importlib
+known_third_party=django,shuup,six
+length_sort=false
+line_length=79
+multi_line_output=4
+order_by_type=false
+skip=migrations
+not_skip=__init__.py
+wrap_length=79

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import setuptools
 
-
 if __name__ == '__main__':
     setuptools.setup(
         name="shuup-stripe",

--- a/shuup_stripe/__init__.py
+++ b/shuup_stripe/__init__.py
@@ -25,5 +25,4 @@ class ShuupStripeAppConfig(AppConfig):
         ]
     }
 
-
 default_app_config = "shuup_stripe.ShuupStripeAppConfig"

--- a/shuup_stripe/admin_forms.py
+++ b/shuup_stripe/admin_forms.py
@@ -5,14 +5,11 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from django import forms
-
 from shuup.admin.forms import ShuupAdminForm
 from shuup.admin.modules.service_providers.wizard_form_defs import (
-    ServiceWizardFormDef
-)
+    ServiceWizardFormDef)
 from shuup.admin.modules.service_providers.wizard_forms import (
-    ServiceWizardForm
-)
+    ServiceWizardForm)
 
 from .models import StripeCheckoutPaymentProcessor
 

--- a/shuup_stripe/checkout_forms.py
+++ b/shuup_stripe/checkout_forms.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup Stripe Addon.
+#
+# Copyright (c) 2012-2016, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django import forms
+
+
+class StripeTokenForm(forms.Form):
+    # We're using camel case here only because that's what Stripe does
+    stripeToken = forms.CharField(widget=forms.HiddenInput, required=True)
+    stripeTokenType = forms.CharField(widget=forms.HiddenInput, required=False)
+    stripeEmail = forms.CharField(widget=forms.HiddenInput, required=False)

--- a/shuup_stripe/checkout_phase.py
+++ b/shuup_stripe/checkout_phase.py
@@ -5,25 +5,17 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-
-from django import forms
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext as _
 from django.views.generic.edit import FormView
-from shuup.front.checkout import (
-    BasicServiceCheckoutPhaseProvider, CheckoutPhaseViewMixin
-)
+
+from shuup.front.checkout import (BasicServiceCheckoutPhaseProvider,
+                                  CheckoutPhaseViewMixin)
 from shuup.utils.excs import Problem
 
+from .checkout_forms import StripeTokenForm
 from .models import StripeCheckoutPaymentProcessor
 from .utils import get_amount_info
-
-
-class StripeTokenForm(forms.Form):
-    # We're using camel case here only because that's what Stripe does
-    stripeToken = forms.CharField(widget=forms.HiddenInput, required=True)
-    stripeTokenType = forms.CharField(widget=forms.HiddenInput, required=False)
-    stripeEmail = forms.CharField(widget=forms.HiddenInput, required=False)
 
 
 class StripeCheckoutPhase(CheckoutPhaseViewMixin, FormView):

--- a/shuup_stripe/checkout_phase.py
+++ b/shuup_stripe/checkout_phase.py
@@ -8,9 +8,8 @@
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext as _
 from django.views.generic.edit import FormView
-
-from shuup.front.checkout import (BasicServiceCheckoutPhaseProvider,
-                                  CheckoutPhaseViewMixin)
+from shuup.front.checkout import (
+    BasicServiceCheckoutPhaseProvider, CheckoutPhaseViewMixin)
 from shuup.utils.excs import Problem
 
 from .checkout_forms import StripeTokenForm

--- a/shuup_stripe/models.py
+++ b/shuup_stripe/models.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-
 from shuup.core.models import PaymentProcessor, ServiceChoice
 
 from .module import StripeCharger

--- a/shuup_stripe/module.py
+++ b/shuup_stripe/module.py
@@ -7,7 +7,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from django.utils.translation import ugettext as _
-
 from shuup.utils.excs import Problem
 from shuup.utils.http import retry_request
 

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -5,18 +5,15 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.utils.timezone import now
 import os
 
 import pytest
+from django.utils.timezone import now
 from shuup.front.basket import get_basket
-from shuup.utils.excs import Problem
 from shuup.testing.factories import (
-    get_default_product,
-    get_default_supplier,
-    get_default_tax_class,
-    create_order_with_product,
-    get_default_shop)
+    create_order_with_product, get_default_product, get_default_shop,
+    get_default_supplier, get_default_tax_class)
+from shuup.utils.excs import Problem
 from shuup.utils.http import retry_request
 
 from shuup_stripe.checkout_phase import StripeCheckoutPhase


### PR DESCRIPTION
This change is required because using this form in other addon
causes circular import. The original place was also odd :)