### PR TITLE
Simplify test configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,14 @@
 sudo: false
 language: python
-cache:
-  directories:
-    - "$HOME/.cache/pip"
-    - "$HOME/.cache/shuup/build_resources"
-    - "$HOME/.nvm"
-env:
-  - DEBUG=1
+cache: pip
 python:
   - "2.7"
   - "3.4"
 install:
-  - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash
-  - source ~/.nvm/nvm.sh && nvm install 4
   - pip install -U pip setuptools
+  - pip install codecov
   - pip install shuup
   - pip install -r requirements-test.txt
 script:
   - py.test -ra -vvv --nomigrations tests --cov
-after_success: coveralls
+after_success: codecov

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
-coveralls
 pytest>=2.8
 pytest-cov
 pytest-django>=2.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = shuup-stripe
-version = attr: shuup_stripe.__version__
+version = 0.5.0
 description = Stripe Checkout integration for Shuup
 long_description = file: README.rst
 keywords = stripe, shuup

--- a/shuup_stripe/__init__.py
+++ b/shuup_stripe/__init__.py
@@ -6,9 +6,13 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
+import pkg_resources
 from shuup.apps import AppConfig
 
-__version__ = '0.5.0'
+try:
+    __version__ = pkg_resources.get_distribution(__name__).version
+except pkg_resources.DistributionNotFound:
+    __version__ = None
 
 
 class ShuupStripeAppConfig(AppConfig):


### PR DESCRIPTION
* Use the "cache: pip" option of Travis for caching.
* Remove unneeded Node.js
* Use codecov rather than coveralls