### PR TITLE
Stripe Connect: Enable OAuth in maintenance

### DIFF
--- a/shuup_stripe/urls.py
+++ b/shuup_stripe/urls.py
@@ -7,8 +7,8 @@
 # LICENSE file in the root directory of this source tree.
 from django.conf.urls import url
 
-from shuup_stripe.views import OAuthCallbackView
+from shuup_stripe.views.oauth import stripe_oauth_callback
 
 urlpatterns = [
-    url(r'^stripe/connect/$', OAuthCallbackView.as_view(), name='stripe_connect_auth'),
+    url(r'^stripe/connect/$', stripe_oauth_callback, name='stripe_connect_auth'),
 ]

--- a/shuup_stripe/views/__init__.py
+++ b/shuup_stripe/views/__init__.py
@@ -5,8 +5,8 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from .oauth import OAuthCallbackView
+from .oauth import stripe_oauth_callback
 
 __all__ = [
-    "OAuthCallbackView"
+    "stripe_oauth_callback"
 ]

--- a/shuup_stripe/views/oauth.py
+++ b/shuup_stripe/views/oauth.py
@@ -9,7 +9,6 @@ import json
 
 from django.conf import settings
 from django.http import HttpResponseBadRequest
-from django.views.generic import View
 from shuup import configuration
 from shuup.core.models import Shop
 from shuup.utils.importing import load
@@ -18,8 +17,7 @@ from shuup_stripe.utils import (
     ensure_stripe_method_for_shop, ensure_stripe_token)
 
 
-class OAuthCallbackView(View):
-    redirect_provider_key = "shuup_stripe_redirect_provider"
+def stripe_oauth_callback(request):
     """
     View for Stripe OAuth Callback
 
@@ -29,27 +27,25 @@ class OAuthCallbackView(View):
     Once the information has been fetched, the
     user is being redirected to admin.
     """
+    if request.method != "GET":
+        return HttpResponseBadRequest("invalid request")
+    if "state" not in request.GET:
+        return HttpResponseBadRequest("invalid request")
+    if "code" not in request.GET:
+        return HttpResponseBadRequest("invalid request")
+    authorization_code = request.GET["code"]
+    # do auth
+    try:
+        shop_id = int(request.GET["state"].split("_")[2])
+        shop = Shop.objects.get(id=shop_id)
+    except (IndexError, Shop.DoesNotExist):
+        return HttpResponseBadRequest("invalid request")
 
-    def dispatch(self, request, *args, **kwargs):
-        if request.method != "GET":
-            return HttpResponseBadRequest("invalid request")
-        if "state" not in request.GET:
-            return HttpResponseBadRequest("invalid request")
-        if "code" not in request.GET:
-            return HttpResponseBadRequest("invalid request")
-        authorization_code = request.GET["code"]
-        # do auth
-        try:
-            shop_id = int(request.GET["state"].split("_")[2])
-            shop = Shop.objects.get(id=shop_id)
-        except (IndexError, Shop.DoesNotExist):
-            return HttpResponseBadRequest("invalid request")
+    ensure_stripe_token(shop, authorization_code)
+    conf = json.loads(configuration.get(shop, settings.STRIPE_CONNECT_OAUTH_DATA_KEY, "{}"))
+    if conf:
+        ensure_stripe_method_for_shop(shop, conf["stripe_publishable_key"])
 
-        ensure_stripe_token(shop, authorization_code)
-        conf = json.loads(configuration.get(shop, settings.STRIPE_CONNECT_OAUTH_DATA_KEY, "{}"))
-        if conf:
-            ensure_stripe_method_for_shop(shop, conf["stripe_publishable_key"])
-
-        rd = load(settings.STRIPE_OAUTH_REDIRECTOR)
-        redirector = rd(shop)
-        return redirector.redirect()
+    rd = load(settings.STRIPE_OAUTH_REDIRECTOR)
+    redirector = rd(shop)
+    return redirector.redirect()


### PR DESCRIPTION
When `shop` was in maintenance mode the `ShuupFrontMiddleware` prevented OAuth to work. This commit fixes that issue.