### PR TITLE
Improve descriptions, help texts, error messages, etc

### DIFF
--- a/shuup_stripe/checkout_forms.py
+++ b/shuup_stripe/checkout_forms.py
@@ -19,6 +19,6 @@ class StripeTokenForm(forms.Form):
     def clean(self):
         data = super(StripeTokenForm, self).clean()
         if not (data.get("stripeToken") or data.get("stripeCustomer")):
-            raise forms.ValidationError(_("Either token or curstomer should be informed."))
+            raise forms.ValidationError(_("Either token or customer should be informed."))
 
         return data

--- a/shuup_stripe/checkout_phase.py
+++ b/shuup_stripe/checkout_phase.py
@@ -40,7 +40,7 @@ class StripeCheckoutPhase(CheckoutPhaseViewMixin, FormView):
         secret_key = payment_processor.secret_key
         if not (publishable_key and secret_key):
             raise Problem(
-                _("Please configure Stripe keys for payment processor %s.") %
+                _("Please configure Stripe keys for payment processor `%s`.") %
                 payment_processor)
 
         config = {
@@ -68,7 +68,7 @@ class StripeCheckoutPhase(CheckoutPhaseViewMixin, FormView):
                     customer = stripe.Customer.retrieve(stripe_customer.customer_token)
                     context["stripe_customer_data"] = customer.to_dict()
                 except stripe.error.StripeError:
-                    LOGGER.exception("Failed to fetch Stripe customer")
+                    LOGGER.exception("Error! Failed to fetch Stripe customer.")
 
         return context
 

--- a/shuup_stripe/module.py
+++ b/shuup_stripe/module.py
@@ -14,12 +14,12 @@ from shuup_stripe.utils import get_amount_info
 def _handle_stripe_error(charge_data):
     error_dict = charge_data.get("error")
     if error_dict:
-        raise Problem("Stripe: %(message)s (%(type)s)" % error_dict)
+        raise Problem("Error! Stripe: %(message)s (%(type)s)." % error_dict)
     failure_code = charge_data.get("failure_code")
     failure_message = charge_data.get("failure_message")
     if failure_code or failure_message:
         raise Problem(
-            _("Stripe: %(failure_message)s (%(failure_code)s)") % charge_data
+            _("Stripe: %(failure_message)s (%(failure_code)s).") % charge_data
         )
 
 
@@ -63,7 +63,7 @@ class StripeCharger(object):
         charge_data = resp.json() if hasattr(resp, "json") else resp
         _handle_stripe_error(charge_data)
         if not charge_data.get("paid"):
-            raise Problem(_("Stripe Charge does not say 'paid'"))
+            raise Problem(_("Stripe Charge does not say 'paid'."))
 
         return self.order.create_payment(
             self.order.taxful_total_price,

--- a/shuup_stripe/views.py
+++ b/shuup_stripe/views.py
@@ -47,13 +47,13 @@ class StripeSavedPaymentInfoView(DashboardViewMixin, TemplateView):
                     )
 
             except stripe.error.StripeError:
-                LOGGER.exception("Failed to create Stripe Customer")
+                LOGGER.exception("Error! Failed to create Stripe Customer.")
                 stripe_customer = None
 
         if stripe_customer:
-            messages.success(request, _("Payment details successfully saved."))
+            messages.success(request, _("Payment details saved."))
         else:
-            messages.error(request, _("Error while saving payment details."))
+            messages.error(request, _("Failed to save payment details."))
 
         return HttpResponseRedirect(reverse("shuup:stripe_saved_payment"))
 
@@ -93,10 +93,10 @@ class StripeDeleteSavedPaymentInfoView(View):
                 customer = stripe.Customer.retrieve(stripe_customer.customer_token)
                 customer.sources.retrieve(source_id).delete()
             except stripe.error.StripeError:
-                LOGGER.exception("Failed to delete Stripe source")
+                LOGGER.exception("Error! Failed to delete Stripe source.")
                 messages.error(request, _("Unknown error while removing payment details."))
 
             else:
-                messages.success(request, _("Payment successfully removed."))
+                messages.success(request, _("Payment was removed."))
 
         return HttpResponseRedirect(reverse("shuup:stripe_saved_payment"))


### PR DESCRIPTION
This is part of a big update to improve various texts in Shuup.

A lot of changes, touching almost every individual Shuup project's repo.

There are too many changes to try to describe them separately, but the 
main ones are:
1. Improve `help_text` descriptions. Fix typos, rewrite and change, 
write new ones.
2. Change some of the model field names (for example rename 
`available_from` -> `available_since`; `available_to` `available_until` 
- this is in a separate commit).
3. Improve some of the documentation.
4. Improve some in-code-comments.
5. Improve `settings.py` files. It's now clearer what each option does.
6. Change some of the naming.
7. Change the error/message system.

The main Shuup repo's Merge Request is here: 
https://github.com/shuup/shuup/pull/2113 (with a reasoning behind 
changes).